### PR TITLE
Add support for environments that support touch and pointer events.

### DIFF
--- a/jquery.touchSwipe.js
+++ b/jquery.touchSwipe.js
@@ -556,14 +556,15 @@
 			var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 			
 			var ret,
-				evt = SUPPORTS_TOUCH ? event.touches[0] : event;
+				touches = event.touches,
+				evt = touches ? touches[0] : event;
 
 			phase = PHASE_START;
 
 			//If we support touches, get the finger count
-			if (SUPPORTS_TOUCH) {
+			if (touches) {
 				// get the total number of fingers touching the screen
-				fingerCount = event.touches.length;
+				fingerCount = touches.length;
 			}
 			//Else this is the desktop, so stop the browser from dragging content
 			else {
@@ -585,7 +586,7 @@
 
 			
 			// check the number of fingers is what we are looking for, or we are capturing pinches
-			if (!SUPPORTS_TOUCH || (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches()) {
+			if (!touches || (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || hasPinches()) {
 				// get the coordinates of the touch
 				createFingerData( 0, evt );
 				startTime = getTimeStamp();
@@ -593,7 +594,7 @@
 				if(fingerCount==2) {
 					//Keep track of the initial pinch distance, so we can calculate the diff later
 					//Store second finger data as start
-					createFingerData( 1, event.touches[1] );
+					createFingerData( 1, touches[1] );
 					startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
 				}
 				
@@ -649,15 +650,16 @@
 				return;
 
 			var ret,
-				evt = SUPPORTS_TOUCH ? event.touches[0] : event;
+				touches = event.touches,
+				evt = touches ? touches[0] : event;
 			
 
 			//Update the  finger data 
 			var currentFinger = updateFingerData(evt);
 			endTime = getTimeStamp();
 			
-			if (SUPPORTS_TOUCH) {
-				fingerCount = event.touches.length;
+			if (touches) {
+				fingerCount = touches.length;
 			}
 
 			if (options.hold)
@@ -672,12 +674,12 @@
 				//We do this here as well as the start event, in case they start with 1 finger, and the press 2 fingers
 				if(startTouchesDistance==0) {
 					//Create second finger if this is the first time...
-					createFingerData( 1, event.touches[1] );
+					createFingerData( 1, touches[1] );
 					
 					startTouchesDistance = endTouchesDistance = calculateTouchesDistance(fingerData[0].start, fingerData[1].start);
 				} else {
 					//Else just update the second finger
-					updateFingerData(event.touches[1]);
+					updateFingerData(touches[1]);
 				
 					endTouchesDistance = calculateTouchesDistance(fingerData[0].end, fingerData[1].end);
 					pinchDirection = calculatePinchDirection(fingerData[0].end, fingerData[1].end);
@@ -691,7 +693,7 @@
 			
 			
 
-			if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !SUPPORTS_TOUCH || hasPinches() ) {
+			if ( (fingerCount === options.fingers || options.fingers === ALL_FINGERS) || !touches || hasPinches() ) {
 				
 				direction = calculateDirection(currentFinger.start, currentFinger.end);
 				
@@ -757,13 +759,14 @@
 		*/
 		function touchEnd(jqEvent) {
 			//As we use Jquery bind for events, we need to target the original event object
-			var event = jqEvent.originalEvent;
-				
+			//If these events are being programmatically triggered, we don't have an original event object, so use the Jq one.
+			var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent,
+			    touches = event.touches;
 
 			//If we are still in a touch with another finger return
 			//This allows us to wait a fraction and see if the other finger comes up, if it does within the threshold, then we treat it as a multi release, not a single release.
-			if (SUPPORTS_TOUCH) {
-				if(event.touches.length>0) {
+			if (touches) {
+				if(touches.length) {
 					startMultiFingerRelease();
 					return true;
 				}
@@ -839,7 +842,7 @@
 		* @inner
 		*/
 		function touchLeave(jqEvent) {
-			var event = jqEvent.originalEvent;
+			var event = jqEvent.originalEvent ? jqEvent.originalEvent : jqEvent;
 			
 			//If we have the trigger on leave property set....
 			if(options.triggerOnTouchLeave) {
@@ -904,8 +907,9 @@
 		* @inner
 		*/
 		function triggerHandler(event, phase) {
-			
-			var ret = undefined;
+
+			var ret,
+				touches = event.touches;
 			
 			//Swipes and pinches are not mutually exclusive - can happend at same time, so need to trigger 2 events potentially
 			if( (didSwipe() || hasSwipes()) || (didPinch() || hasPinches()) ) {
@@ -951,8 +955,8 @@
 			// If we are ending the gesture, then manually trigger the reset handler IF all fingers are off
 			if(phase === PHASE_END) {
 				//If we support touch, then check that all fingers are off before we cancel
-				if (SUPPORTS_TOUCH) {
-					if(event.touches.length==0) {
+				if (touches) {
+					if(!touches.length) {
 						touchCancel(event);	
 					}
 				} 
@@ -977,7 +981,7 @@
 		*/
 		function triggerHandlerForGesture(event, phase, gesture) {	
 			
-			var ret=undefined;
+			var ret;
 			
 			//SWIPES....
 			if(gesture==SWIPE) {


### PR DESCRIPTION
Some devices support both pointer events and touch events depending and depending on how the event is trigger may or may not have `event.touches`. This PR replaces many of the `SUPPORTS_TOUCH` with truthy checks for `event.touches`.